### PR TITLE
Fix for hash key conversions with arrays of hashes

### DIFF
--- a/lib/hash_pipe/key_conversion.rb
+++ b/lib/hash_pipe/key_conversion.rb
@@ -3,13 +3,14 @@ Hash.class_eval do
   def self.convert_keys(hash, method = :underscore)
     if hash.is_a?(Array)
       hash.collect {|h| convert_keys(h, method) }
-    else
+    elsif hash.is_a?(Hash)
       hash_array = hash.collect do |key,value|
-        value = value.is_a?(Hash) ? convert_keys(value, method) : value
-        [ key.to_s.send(method), value ]
+        [ key.to_s.send(method), convert_keys(value, method) ]
       end
 
       Hash[hash_array]
+    else
+      hash
     end
   end
 

--- a/spec/hash-pipe/key_conversion_spec.rb
+++ b/spec/hash-pipe/key_conversion_spec.rb
@@ -27,4 +27,12 @@ describe 'key_conversion' do
     Hash.convert_keys([{ 'HELLO' => 'world' }, { 'FOO' => 'bar' }]).should eq [{ 'hello' => 'world' }, { 'foo' => 'bar' }]
   end
 
+  it 'should convert arrays of hashes' do
+    { 'HELLO' => [{ 'MR' => 'world' }] }.convert_keys.should eq 'hello' => [{'mr' => 'world'}]
+  end
+
+  it 'should not convert values other than arrays and hashes' do
+    Hash.convert_keys("HELLO WORLD").should eq "HELLO WORLD"
+  end
+
 end


### PR DESCRIPTION
I found that it wasn't properly converting arrays of hashes. This fixes that and makes it possible to pass anything into convert_keys and it will leave anything but arrays and hashes untouched.
