### PR TITLE
Procs as converters

### DIFF
--- a/lib/hash_pipe/key_conversion.rb
+++ b/lib/hash_pipe/key_conversion.rb
@@ -1,11 +1,17 @@
 Hash.class_eval do
 
   def self.convert_keys(hash, method = :underscore)
+    if method.is_a? Proc
+      converter = method
+    else
+      converter = -> (str) { str.to_s.send method }
+    end
+
     if hash.is_a?(Array)
-      hash.collect {|h| convert_keys(h, method) }
+      hash.collect {|h| convert_keys(h, converter) }
     elsif hash.is_a?(Hash)
       hash_array = hash.collect do |key,value|
-        [ key.to_s.send(method), convert_keys(value, method) ]
+        [ converter.call(key), convert_keys(value, converter) ]
       end
 
       Hash[hash_array]

--- a/spec/hash-pipe/key_conversion_spec.rb
+++ b/spec/hash-pipe/key_conversion_spec.rb
@@ -35,4 +35,9 @@ describe 'key_conversion' do
     Hash.convert_keys("HELLO WORLD").should eq "HELLO WORLD"
   end
 
+  it 'should support lambdas for conversion methods' do
+    converter = -> (str) { str.sub "hello", "goodbye" }
+    { 'hello' => 'world' }.convert_keys(converter).should eq 'goodbye' => 'world'
+  end
+
 end


### PR DESCRIPTION
Making it possible to have more complex key conversion methods by accepting procs instead of always expecting a method name which blindly gets sent to the key string.

@erkie what do you think?